### PR TITLE
Check correct assets folder existence

### DIFF
--- a/advanced-custom-fields.php
+++ b/advanced-custom-fields.php
@@ -21,7 +21,7 @@ if (function_exists('add_filter')) {
 
     // Set Sage9 friendly path at /theme-directory/resources/assets/acf-json
 
-        if (is_dir(get_stylesheet_directory() . '/assets/acf-json')) {
+        if (is_dir(get_stylesheet_directory() . '/assets')) {
             // This is Sage 9
             $path = get_stylesheet_directory() . '/assets/acf-json';
         } else {


### PR DESCRIPTION
Using Sage 9, in first call, if acf-json folder doesn't exist (as it hasn't been created yet), the saving function from ACF returns a Warning: mkdir(): No such file or directory as the path that is trying to create doesn't exist as the code goes the Sage 10 else...

Before:
themes/theme-name/resources/resources/assets/acf-json

After
themes/theme-name/resources/assets/acf-json

Fixed checking the correct folder existence for Sage 9